### PR TITLE
craft_ prefix compatibility and limiting to availableForPurchase

### DIFF
--- a/src/Variable.php
+++ b/src/Variable.php
@@ -34,6 +34,7 @@ class Variable
 	 *
 	 * @param Product|Order     $target
 	 * @param int               $limit
+	 * @param bool              $includeAll
 	 * @param ProductQuery|null $paddingQuery
 	 *
 	 * @return ProductQuery
@@ -43,6 +44,7 @@ class Variable
 	public function related (
 		$target,
 		$limit = 8,
+		$includeAll = true,
 		ProductQuery $paddingQuery = null
 	) {
 		$service = PurchasePatterns::getInstance()->getService();
@@ -52,6 +54,7 @@ class Variable
 			return $service->getRelatedToProductCriteria(
 				$target,
 				$limit,
+				$includeAll,
 				$paddingQuery
 			);
 		}
@@ -61,6 +64,7 @@ class Variable
 			return $service->getRelatedToOrderCriteria(
 				$target,
 				$limit,
+				$includeAll,
 				$paddingQuery
 			);
 		}

--- a/src/elements/db/ProductQueryExtended.php
+++ b/src/elements/db/ProductQueryExtended.php
@@ -22,7 +22,7 @@ class ProductQueryExtended extends ProductQuery
 	protected function beforePrepare (): bool
 	{
 		$this->innerJoin(
-			'{{%purchase_counts}}',
+			'{{%purchase_counts}} purchase_counts',
 			'[[commerce_products.id]] = [[purchase_counts.product_id]]'
 		);
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Add table alias for `innerJoin` used in `ProductQueryExtended`

In its current form, `ProductQueryExtended` produces the following error on Craft 3 installs using databases migrated from Craft 2 with the `craft_` table prefix:

>SQLSTATE[42S22]: Column not found: 1054 Unknown column 'purchase_counts.order_count' in 'field list'

Adding a table alias to the `innerJoin` resolves this issue.