### PR TITLE
Fixed query issues and added ability to pre-filter purchase patterns

### DIFF
--- a/src/Variable.php
+++ b/src/Variable.php
@@ -35,6 +35,7 @@ class Variable
 	 * @param Product|Order     $target
 	 * @param int               $limit
 	 * @param ProductQuery|null $paddingQuery
+     * @param array             $filters
 	 *
 	 * @return ProductQuery
 	 * @throws InvalidConfigException
@@ -43,7 +44,8 @@ class Variable
 	public function related (
 		$target,
 		$limit = 8,
-		ProductQuery $paddingQuery = null
+		ProductQuery $paddingQuery = null,
+        array $filters = []
 	) {
 		$service = PurchasePatterns::getInstance()->getService();
 
@@ -52,7 +54,8 @@ class Variable
 			return $service->getRelatedToProductCriteria(
 				$target,
 				$limit,
-				$paddingQuery
+				$paddingQuery,
+                $filters
 			);
 		}
 
@@ -61,7 +64,8 @@ class Variable
 			return $service->getRelatedToOrderCriteria(
 				$target,
 				$limit,
-				$paddingQuery
+				$paddingQuery,
+                $filters
 			);
 		}
 

--- a/src/elements/db/ProductQueryExtended.php
+++ b/src/elements/db/ProductQueryExtended.php
@@ -21,7 +21,7 @@ class ProductQueryExtended extends ProductQuery
 
 	protected function beforePrepare (): bool
 	{
-		$this->innerJoin(
+		$this->leftJoin(
 			'{{%purchase_counts}} purchase_counts',
 			'[[commerce_products.id]] = [[purchase_counts.product_id]]'
 		);


### PR DESCRIPTION
Changes proposed in this pull request:

### Change `ProductQueryExtended` join
Currently, using `innerJoin()` only returns products that have a record in the `purchase_counts` table. As a result, it could render the `paddingQuery` useless, especially in cases such as new shops where a majority of products may not have any purchase records. Using `leftJoin()` resolves this issue.

### Exclude purchase pattern IDs from `paddingQuery`
Currently product IDs queried from the `purchase_patterns` table are not excluded from the `paddingQuery`. This can result in returning a query with fewer products that the designated `limit` when a duplicate ID is returned by the `paddingQuery`. The `_mergeIds()` method examines any existing `id` property of the `paddingQuery` and excludes any of the product IDs found in `purchase_patterns` before executing the query.

### Add ability to filter IDs queried from `purchase_patterns`
This was something I tried to resolve in a [previous pull request](https://github.com/ethercreative/purchase-patterns/pull/1) but was not merged for the reasons outlined in [this comment](https://github.com/ethercreative/purchase-patterns/pull/1#issuecomment-545829054). While I initially thought I could resolve the issue using method suggested in the comment, I found that there are scenarios (especially when using a `limit`) where it does not work as desired.

```twig
{% set customersAlsoBought = craft.purchasePatterns.related(
    product,
    3,
    craft.products.relatedTo(product.myCategory).availableForPurchase(1)
).availableForPurchase(1).all() %}
```
**Example 1:**
The `related()` above returns three products, but they all have `availableForPurchase` set to false. They are subsequently filtered by `.availableForPurchase(1)`, returning an empty array.

**Example 2:**
The `related()` above retrieves 1 product from `purchase_patterns`, filling in the remaining two products with the `paddingQuery`. The two products have `availableForPurchase` set to true, but the product from `purchase_patterns` does not. The query is subsequently filtered by `.availableForPurchase(1)`, returning an array of two products instead of three.

I added a `filters` parameter and deferred limiting until a second query that applies the filters to product Ids from `purchase_patterns`. Doing so allows these relationships to be queried with criteria while still ensuring results that consistently match the limit. The query above would be revised to:
```twig
{% set customersAlsoBought = craft.purchasePatterns.related(
    product,
    3,
    craft.products.relatedTo(product.myCategory).availableForPurchase(1),
    { availableForPurchase: 1 }
).all() %}
```

This could also be useful in other situations, such as only retrieving purchase patterns for certain product types (e.g. excluding replacement parts so only retail products are returned).

Thanks for your consideration!