### PR TITLE
Fixed filtered query result order

### DIFF
--- a/src/Service.php
+++ b/src/Service.php
@@ -144,7 +144,8 @@ SQL;
         if (!empty($filters)) {
             $query = Product::find()
                 ->id($productIds)
-                ->limit($limit);
+                ->limit($limit)
+		->fixedOrder();
 
             foreach ($filters as $prop => $val) {
                 $query->$prop($val);
@@ -217,7 +218,8 @@ SQL;
         if (!empty($filters)) {
             $query = Product::find()
                 ->id($productIds)
-                ->limit($limit);
+                ->limit($limit)
+		->fixedOrder();
 
             foreach ($filters as $prop => $val) {
                 $query->$prop($val);


### PR DESCRIPTION
Thanks for implementing my last pull request. I noticed I missed one detail for filtered queries, causing the filtered query to not return in the original order (by purchase count). Adding `fixedOrder()` to filtered queries fixes the issue. Sorry for the hiccup!