### PR TITLE
Removed unnecessary div closing tag

### DIFF
--- a/src/templates/_product/edit.twig
+++ b/src/templates/_product/edit.twig
@@ -1,4 +1,3 @@
-</div>
 <hr>
 <div class="meta" style="padding-top:20px;padding-bottom:20px">
 	<h4>{{ 'Purchased With'|t('purchase-patterns') }}</h4>


### PR DESCRIPTION
The html for the `cp.commerce.product.edit.details` hook includes an extra `div` closing tag that causes the *Purchased With* meta to render incorrectly. I believe this was originally to accommodate the `cp.commerce.product.edit.details` hook being called in the wrong place, which has since been fixed (craftcms/commerce#1376).