### PR TITLE
Fix strict comparison product id filtering

### DIFF
--- a/src/Service.php
+++ b/src/Service.php
@@ -131,7 +131,7 @@ SQL;
 
 		foreach ($results as $result)
 			$productIds[] =
-				$result['product_a'] === $id
+				$result['product_a'] == $id
 					? $result['product_b']
 					: $result['product_a'];
 


### PR DESCRIPTION
Running into an issue where the initial query was returning product IDs as strings, preventing the related products IDs from being filtered properly. Changing the comparison from strict to loose resolves this issue.